### PR TITLE
Board format as 1-line string

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,8 @@
+{:paths ["src"]
+ :deps {org.clojure/clojure {:mvn/version "1.8.0"}
+        org.clojure/math.numeric-tower {:mvn/version "0.0.4"}
+        ;org.clojure/tools.namespace {:mvn/verson "0.2.11"}
+        }
+ :aliases {:uberjar {:extra-deps {uberdeps {:mvn/version "0.1.4"}}
+                     :main-opts  ["-m" "uberdeps.uberjar"]}}}
+

--- a/src/boggle/core.clj
+++ b/src/boggle/core.clj
@@ -1,8 +1,8 @@
 (ns boggle.core
-    (:use [clojure.math.numeric-tower :only [abs]]
-          [clojure.java.io :as io])
-    (:require [clojure.string :as string])
-    (:gen-class))
+  (:require [clojure.string :as string]
+            [clojure.java.io :as io]
+            [clojure.math.numeric-tower :refer [abs]])
+  (:gen-class))
 
 (def dict (io/resource "ospd.txt"))
 

--- a/src/boggle/utils.clj
+++ b/src/boggle/utils.clj
@@ -1,0 +1,16 @@
+(ns boggle.utils
+  (:require [clojure.string :as str]
+            [clojure.math.numeric-tower :refer [sqrt]]))
+
+(defn str->board
+  "Converts a string, `s`, into a board formatted to be accepted by
+  `boggle.core/load-board`. nil is returned if `s` cannot be a square board."
+  [s]
+  (let [board-size (sqrt (count s))]
+    (when (integer? board-size)
+      (->> s
+           str/upper-case
+           (map #(if (= \Q %) "QU" %))
+           (partition board-size)
+           (map #(str/join \  %))
+           (str/join "\n")))))

--- a/test/boggle/core_test.clj
+++ b/test/boggle/core_test.clj
@@ -1,6 +1,7 @@
 (ns boggle.core-test
   (:require [clojure.test :refer :all]
-            [boggle.core :refer :all]))
+            [boggle.core :refer :all]
+            [boggle.utils]))
 
 (deftest test-valid-word?
     (testing "valid-word?"
@@ -127,3 +128,13 @@
                    [["A" "B" "C"]
                     ["D" "E" "F"]
                     ["P" "QU" "R"]])))))
+
+(deftest test-load-board-from-string
+  (testing "correctly parses a 1-line string into a board matrix"
+    (let [board    (boggle.utils/str->board "abcdefpqr")
+          actual   (load-board board)
+          expected [["A" "B" "C"]
+                    ["D" "E" "F"]
+                    ["P" "QU" "R"]]]
+      (is (= "A B C\nD E F\nP QU R" board))
+      (is (= expected actual)))))


### PR DESCRIPTION
I wanted the ability to represent the board as a 1-line string.  Figured I would share it back if you find it useful.
